### PR TITLE
#ieeesoc feat(auth): add eye icon to toggle password visibility on login and s…

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
+import PasswordInput from "/workspaces/local-loop/frontend/components/PasswordInput"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
@@ -70,13 +71,12 @@ export default function LoginPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="password" className="text-sm font-medium">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  required
+                <PasswordInput
+                  name="password"
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full"
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="Password"
+                  required
                 />
               </div>
             </div>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
+import PasswordInput from "/workspaces/local-loop/frontend/components/PasswordInput"
 
 export default function SignupPage() {
   const [name, setName] = useState("")
@@ -94,25 +95,23 @@ export default function SignupPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="password" className="text-sm font-medium">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  required
+                <PasswordInput
+                  name="password"
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full"
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="Password"
+                  required
                 />
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="confirmPassword" className="text-sm font-medium">Confirm Password</Label>
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  required
+                <PasswordInput
+                  name="confirmPassword"
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="w-full"
+                  onChange={e => setConfirmPassword(e.target.value)}
+                  placeholder="Confirm Password"
+                  required
                 />
               </div>
             </div>

--- a/frontend/components/PasswordInput.tsx
+++ b/frontend/components/PasswordInput.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
+type PasswordInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export default function PasswordInput(props: PasswordInputProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        {...props}
+        type={show ? "text" : "password"}
+        style={{ paddingRight: "2rem", width: "100%" }}
+      />
+      <span
+        onClick={() => setShow((s) => !s)}
+        style={{
+          position: "absolute",
+          right: 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          cursor: "pointer",
+          userSelect: "none",
+          display: "flex",
+          alignItems: "center",
+        }}
+        tabIndex={0}
+        role="button"
+        aria-label={show ? "Hide password" : "Show password"}
+      >
+        <FontAwesomeIcon icon={show ? faEyeSlash : faEye} size="lg" />
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/auth-provider.tsx
+++ b/frontend/components/auth-provider.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 
+
 import { createContext, useContext, useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 
@@ -184,7 +185,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
     router.push("/login")
   }
-
   return <AuthContext.Provider value={{ user, login, signup, logout, isLoading, token }}>{children}</AuthContext.Provider>
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "localloop",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -138,6 +141,52 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",


### PR DESCRIPTION
🚀 Pull Request closes 
#8

📝 Description
-----
This PR adds password visibility toggle functionality (eye and eye-slash icons) to the password and confirm password fields on the Sign Up and Login pages. This improves user experience by allowing users to view or hide their password input.
-----
🛠 Changes
-----
Added a reusable PasswordInput component with FontAwesome eye/eye-slash icons
Updated Sign Up and Login forms to use PasswordInput for password and confirm password fields
Improved accessibility and usability for password entry fields
-----
## ✅ Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if necessary

## 📸 Screenshots (if applicable)

<img width="949" alt="Screenshot 2025-05-24 at 5 49 06 PM" src="https://github.com/user-attachments/assets/1dbb7094-3b4c-4f3c-a2e0-e66cf1ccc3eb" />
<img width="928" alt="Screenshot 2025-05-24 at 5 46 26 PM" src="https://github.com/user-attachments/assets/60453395-bae6-4937-8f4d-eaf6760a8dcb" />
